### PR TITLE
Setup Prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
-    "serve": "docusaurus serve"
+    "serve": "docusaurus serve",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@docusaurus/core": "^2.3.1",


### PR DESCRIPTION
- `package.json` に `format` スクリプトを入れました。
- Prettier の VS Code 拡張機能をおすすめするようにしました。
- VS Code のフォーマッターを Prettier にセットしました。