### PR TITLE
Fix typo

### DIFF
--- a/docs/4-advanced/02-bundler/index.md
+++ b/docs/4-advanced/02-bundler/index.md
@@ -73,7 +73,7 @@ Vite 内蔵のウェブサーバーが起動し、`http://localhost:5173/` で�
 
 ## Vite の仕組み
 
-Vite の挙動を理解するため、`Ctrl + C` で先ほど起動させたウェブサーバを停止させ、`npm run build` コマンドを実行してみましょう。
+Vite の挙動を理解するため、`Ctrl + C` で先ほど起動させたウェブサーバーを停止させ、`npm run build` コマンドを実行してみましょう。
 
 ```shell
 $ npm run build


### PR DESCRIPTION
サーバーが 86 件、サーバが 1 件だったので、サーバーに統一しました。
間違ってマージ先を master にしちゃってたので、develop にもマージします。ごめんなさい。