### PR TITLE
Rename yearOfBirth to birthYear

### DIFF
--- a/docs/2-browser-apps/04-class/index.md
+++ b/docs/2-browser-apps/04-class/index.md
@@ -150,11 +150,11 @@ class Student {
   age;
 
   // コンストラクタを定義する
-  constructor(name, yearOfBirth, currentYear) {
+  constructor(name, birthYear, currentYear) {
     // this.name は作成されたインスタンスのプロパティ
     // name はインスタンス生成時に代入する値
     this.name = name;
-    this.age = currentYear - yearOfBirth;
+    this.age = currentYear - birthYear;
   }
 
   introduceSelf() {


### PR DESCRIPTION
- 前置詞を使う変数名は冗長なので避けたほうが良い。

試しに、`yearOfBirth` と `birthYear` で GitHub の検索機能を使って調べてみたところ、`birthYear` の方が圧倒的に多くなっていました。

<img width="617" alt="image" src="https://github.com/ut-code/utcode-learn/assets/104971044/cfb74828-8afc-4b85-a9cb-8c127139f56b">

`birthYear` = 160 K

<img width="602" alt="image" src="https://github.com/ut-code/utcode-learn/assets/104971044/e3039407-553d-4365-9d37-9b1aac82d7f6">

`yearOfBirth` = 19 K
