### PR TITLE
Migrate to Prettier 3.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-.docusaurus
-build

--- a/docs/1-trial-session/02-html/_samples/form/index.html
+++ b/docs/1-trial-session/02-html/_samples/form/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/02-html/index.md
+++ b/docs/1-trial-session/02-html/index.md
@@ -18,7 +18,7 @@ Web 開発に必ず用いられる言語があります。<Term type="html" stro
 エディタの画面左端には、ファイル一覧が表示されています。新しいファイルを作成して、`index.html` と名付けましょう。ファイルの中身を次のようにした後、保存します。保存にはショートカットキー ( `Cmd / Ctrl + S` ) を用いてください。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -105,7 +105,7 @@ VS Code 上で作成したファイルは `index.html` でした。しかしな�
 すべての <Term type="html">HTML</Term> ファイルは、
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 ```
 
 という、「このファイルは <Term type="html">HTML</Term> ファイルだ！」と宣言する定型句から始まります。

--- a/docs/1-trial-session/03-javascript/index.md
+++ b/docs/1-trial-session/03-javascript/index.md
@@ -18,7 +18,7 @@ import helloWorldByJavascriptVideo from "./hello-world-by-javascript.mp4"
 まずは、`index.html` を次のように書き換えます。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/05-variables/_samples/compound-assignment/index.html
+++ b/docs/1-trial-session/05-variables/_samples/compound-assignment/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="ja" />

--- a/docs/1-trial-session/06-boolean/_samples/weird-comparison/index.html
+++ b/docs/1-trial-session/06-boolean/_samples/weird-comparison/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/07-if-statement/_samples/the-right-to-vote/index.html
+++ b/docs/1-trial-session/07-if-statement/_samples/the-right-to-vote/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/08-functions/_samples/mobile-phone-bill/index.html
+++ b/docs/1-trial-session/08-functions/_samples/mobile-phone-bill/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="ja" />

--- a/docs/1-trial-session/09-css/_samples/first-css/index.html
+++ b/docs/1-trial-session/09-css/_samples/first-css/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/09-css/_samples/foo/index.html
+++ b/docs/1-trial-session/09-css/_samples/foo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/10-object/_samples/incrementAge/index.html
+++ b/docs/1-trial-session/10-object/_samples/incrementAge/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/11-dom/_samples/css/index.html
+++ b/docs/1-trial-session/11-dom/_samples/css/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/11-dom/_samples/get-element-by-id/index.html
+++ b/docs/1-trial-session/11-dom/_samples/get-element-by-id/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/13-project/_samples/omikuji/index.html
+++ b/docs/1-trial-session/13-project/_samples/omikuji/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/1-trial-session/13-project/_samples/stopwatch/index.html
+++ b/docs/1-trial-session/13-project/_samples/stopwatch/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/01-inspector/index.md
+++ b/docs/2-browser-apps/01-inspector/index.md
@@ -41,7 +41,7 @@ Google Chrome 以外のブラウザにも開発者ツールは搭載されてい
 デバッガを用いることで、プログラムが実行される様子を細かく観測することができます。次のプログラムで試してみましょう。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/02-constant/_samples/answer/index.html
+++ b/docs/2-browser-apps/02-constant/_samples/answer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/02-constant/_samples/object-mutated-by-function/index.html
+++ b/docs/2-browser-apps/02-constant/_samples/object-mutated-by-function/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/02-constant/_samples/reference/index.html
+++ b/docs/2-browser-apps/02-constant/_samples/reference/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/03-loop/_samples/answer-for/index.html
+++ b/docs/2-browser-apps/03-loop/_samples/answer-for/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/03-loop/_samples/answer-while/index.html
+++ b/docs/2-browser-apps/03-loop/_samples/answer-while/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/03-loop/_samples/nested-loop/index.html
+++ b/docs/2-browser-apps/03-loop/_samples/nested-loop/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/03-loop/_samples/times-table/index.html
+++ b/docs/2-browser-apps/03-loop/_samples/times-table/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/04-class/_samples/HTMLDivElement/index.html
+++ b/docs/2-browser-apps/04-class/_samples/HTMLDivElement/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/04-class/_samples/class-car/index.html
+++ b/docs/2-browser-apps/04-class/_samples/class-car/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/04-class/_samples/inheritance-class-SeniorStudent/index.html
+++ b/docs/2-browser-apps/04-class/_samples/inheritance-class-SeniorStudent/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/04-class/_samples/method-incrementAge/index.html
+++ b/docs/2-browser-apps/04-class/_samples/method-incrementAge/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/05-array/_samples/Array-class/index.html
+++ b/docs/2-browser-apps/05-array/_samples/Array-class/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/05-array/_samples/array/index.html
+++ b/docs/2-browser-apps/05-array/_samples/array/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/06-anonymous-function/_samples/every/index.html
+++ b/docs/2-browser-apps/06-anonymous-function/_samples/every/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/06-anonymous-function/_samples/normal-event-handler/index.html
+++ b/docs/2-browser-apps/06-anonymous-function/_samples/normal-event-handler/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/06-anonymous-function/_samples/reduce/index.html
+++ b/docs/2-browser-apps/06-anonymous-function/_samples/reduce/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/06-anonymous-function/_samples/using-anonymous-function/index.html
+++ b/docs/2-browser-apps/06-anonymous-function/_samples/using-anonymous-function/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/07-advanced-css/_samples/separate-css-files/index.html
+++ b/docs/2-browser-apps/07-advanced-css/_samples/separate-css-files/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/07-advanced-css/index.md
+++ b/docs/2-browser-apps/07-advanced-css/index.md
@@ -19,7 +19,7 @@ import ExternalVideoPlayer from "@site/src/components/ExternalVideoPlayer";
 CSS ファイルの拡張子は通常 `.css` です。今回は `index.html` と併せて `style.css` を作成しました。
 
 ```html title=index.html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/absolute/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/absolute/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/box-model/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/box-model/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/display/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/display/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/exercise/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/exercise/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/fixed/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/fixed/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/flex/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/flex/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/grid/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/grid/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/max-min-width/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/max-min-width/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/media-query/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/media-query/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/percent/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/percent/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/relative-absolute/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/relative-absolute/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/relative/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/relative/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/space-around/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/space-around/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/three-div/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/three-div/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/_samples/three-span/index.html
+++ b/docs/2-browser-apps/08-css-arrangement/_samples/three-span/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/08-css-arrangement/index.md
+++ b/docs/2-browser-apps/08-css-arrangement/index.md
@@ -31,7 +31,7 @@ HTML の要素はすべて、一定の高さと幅を持った四角形だと考
 [「ウェブサイトの見た目を整える」ページの課題](https://learn.utcode.net/docs/trial-session/css/#%E8%AA%B2%E9%A1%8C-%E6%99%82%E9%96%93%E3%81%8C%E4%BD%99%E3%81%A3%E3%81%9F%E5%A0%B4%E5%90%88)を例に構造を見てみましょう（構造がわかりやすいよう、`border` を `10px` に変更しています）。
 
 ```html title=index.html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/2-browser-apps/09-project/_samples/addEventListener/index.html
+++ b/docs/2-browser-apps/09-project/_samples/addEventListener/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/2-browser-apps/09-project/_samples/calendar/index.html
+++ b/docs/2-browser-apps/09-project/_samples/calendar/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/2-browser-apps/09-project/_samples/event-target/index.html
+++ b/docs/2-browser-apps/09-project/_samples/event-target/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/05-template-engine/_samples/static-hosting-naive/static/index.html
+++ b/docs/3-web-servers/05-template-engine/_samples/static-hosting-naive/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/05-template-engine/_samples/static-hosting-naive/static/sub/index.html
+++ b/docs/3-web-servers/05-template-engine/_samples/static-hosting-naive/static/sub/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/05-template-engine/_samples/static-hosting-smart/static/index.html
+++ b/docs/3-web-servers/05-template-engine/_samples/static-hosting-smart/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/05-template-engine/_samples/static-hosting-smart/static/sub/index.html
+++ b/docs/3-web-servers/05-template-engine/_samples/static-hosting-smart/static/sub/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/05-template-engine/index.md
+++ b/docs/3-web-servers/05-template-engine/index.md
@@ -144,7 +144,7 @@ app.listen(3000);
 ```
 
 ```html title=template.ejs
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/3-web-servers/06-form/_samples/book-search-system/main.js
+++ b/docs/3-web-servers/06-form/_samples/book-search-system/main.js
@@ -16,7 +16,7 @@ app.use(express.static("static"));
 
 app.get("/send", (request, response) => {
   const selectedBooks = books.filter(
-    (book) => book.author === request.query.author
+    (book) => book.author === request.query.author,
   );
   const template = fs.readFileSync("template.ejs", "utf-8");
   const html = ejs.render(template, { selectedBooks: selectedBooks });

--- a/docs/3-web-servers/06-form/_samples/book-search-system/static/index.html
+++ b/docs/3-web-servers/06-form/_samples/book-search-system/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/3-web-servers/06-form/_samples/send-data-to-server/main.js
+++ b/docs/3-web-servers/06-form/_samples/send-data-to-server/main.js
@@ -4,7 +4,7 @@ const app = express();
 app.use(express.static("static"));
 app.get("/send", (request, response) => {
   response.send(
-    `あなたの名前は${request.query.name}で、${request.query.age}歳ですね。`
+    `あなたの名前は${request.query.name}で、${request.query.age}歳ですね。`,
   );
 });
 app.listen(3000);

--- a/docs/3-web-servers/06-form/_samples/send-data-to-server/static/index.html
+++ b/docs/3-web-servers/06-form/_samples/send-data-to-server/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/3-web-servers/06-form/index.md
+++ b/docs/3-web-servers/06-form/index.md
@@ -74,7 +74,7 @@ form 要素を使うとユーザーの入力からクエリパラメータを生
 以下のコードの、HTML ファイルと、JavaScript ファイルを作成して実行してみましょう。
 
 ```html title="static/index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -97,7 +97,7 @@ const app = express();
 app.use(express.static("static"));
 app.get("/send", (request, response) => {
   response.send(
-    `あなたの名前は${request.query.name}で、${request.query.age}歳ですね。`
+    `あなたの名前は${request.query.name}で、${request.query.age}歳ですね。`,
   );
 });
 app.listen(3000);

--- a/docs/3-web-servers/07-get-post/_samples/post-request/main.js
+++ b/docs/3-web-servers/07-get-post/_samples/post-request/main.js
@@ -7,7 +7,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 app.listen(3000);

--- a/docs/3-web-servers/07-get-post/_samples/post-request/static/index.html
+++ b/docs/3-web-servers/07-get-post/_samples/post-request/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/3-web-servers/07-get-post/index.md
+++ b/docs/3-web-servers/07-get-post/index.md
@@ -24,7 +24,7 @@ HTTP リクエストのこのような区分を、<Term type="httpMethod" strong
 前頁の例を、POST リクエストを用いて書き直してみましょう。`form` 要素の `method` 属性に `post` を指定することで、ブラウザは送信ボタンが押されたときに `POST` メソッドの<Term type="httpRequestResponse">リクエスト</Term>を発行します。
 
 ```html title="static/index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -50,7 +50,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 app.listen(3000);

--- a/docs/4-advanced/01-fetch-api/_samples/chat/static/index.html
+++ b/docs/4-advanced/01-fetch-api/_samples/chat/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/01-fetch-api/_samples/fetch-api/static/index.html
+++ b/docs/4-advanced/01-fetch-api/_samples/fetch-api/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/01-fetch-api/_samples/json-request-body/server.js
+++ b/docs/4-advanced/01-fetch-api/_samples/json-request-body/server.js
@@ -6,7 +6,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 

--- a/docs/4-advanced/01-fetch-api/_samples/json-request-body/static/index.html
+++ b/docs/4-advanced/01-fetch-api/_samples/json-request-body/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/01-fetch-api/_samples/send-post-request/server.js
+++ b/docs/4-advanced/01-fetch-api/_samples/send-post-request/server.js
@@ -6,7 +6,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 

--- a/docs/4-advanced/01-fetch-api/_samples/send-post-request/static/index.html
+++ b/docs/4-advanced/01-fetch-api/_samples/send-post-request/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/01-fetch-api/index.md
+++ b/docs/4-advanced/01-fetch-api/index.md
@@ -76,7 +76,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 
@@ -121,7 +121,7 @@ app.use(express.static("static"));
 
 app.post("/send", (request, response) => {
   response.send(
-    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`
+    `あなたの名前は ${request.body.name}で、${request.body.age}歳ですね。`,
   );
 });
 

--- a/docs/4-advanced/02-bundler/_samples/chartjs/index.html
+++ b/docs/4-advanced/02-bundler/_samples/chartjs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/02-bundler/_samples/es-modules/index.html
+++ b/docs/4-advanced/02-bundler/_samples/es-modules/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/02-bundler/_samples/fullstack-app/client/index.html
+++ b/docs/4-advanced/02-bundler/_samples/fullstack-app/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/02-bundler/_samples/run-npm-package-on-browsers/index.html
+++ b/docs/4-advanced/02-bundler/_samples/run-npm-package-on-browsers/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/02-bundler/_samples/run-npm-package-on-browsers/main.js
+++ b/docs/4-advanced/02-bundler/_samples/run-npm-package-on-browsers/main.js
@@ -2,5 +2,5 @@ import { format } from "date-fns";
 
 document.getElementById("app").textContent = format(
   new Date("2022-01-10"),
-  "yyyy年MM月dd日"
+  "yyyy年MM月dd日",
 );

--- a/docs/4-advanced/02-bundler/index.md
+++ b/docs/4-advanced/02-bundler/index.md
@@ -169,7 +169,7 @@ import { format } from "date-fns";
 
 document.getElementById("app").textContent = format(
   new Date("2022-01-10"),
-  "yyyy年MM月dd日"
+  "yyyy年MM月dd日",
 );
 ```
 

--- a/docs/4-advanced/04-react/_samples/another-test-score/index.html
+++ b/docs/4-advanced/04-react/_samples/another-test-score/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/another-test-score/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/another-test-score/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-component-function/index.html
+++ b/docs/4-advanced/04-react/_samples/react-component-function/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-component-function/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-component-function/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-fixed-input/index.html
+++ b/docs/4-advanced/04-react/_samples/react-fixed-input/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-fixed-input/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-fixed-input/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-hello-world/index.html
+++ b/docs/4-advanced/04-react/_samples/react-hello-world/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-hello-world/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-hello-world/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-input/index.html
+++ b/docs/4-advanced/04-react/_samples/react-input/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-input/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-input/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-prop-forwarding/index.html
+++ b/docs/4-advanced/04-react/_samples/react-prop-forwarding/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-prop-forwarding/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-prop-forwarding/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/react-todo/index.html
+++ b/docs/4-advanced/04-react/_samples/react-todo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/react-todo/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/react-todo/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/student-data/index.html
+++ b/docs/4-advanced/04-react/_samples/student-data/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/student-data/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/student-data/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/test-score/index.html
+++ b/docs/4-advanced/04-react/_samples/test-score/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/test-score/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/test-score/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/todo-database/client/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-database/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/todo-database/client/src/App.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-database/client/src/App.tsx
@@ -72,7 +72,7 @@ export default function App() {
 
   const fixTodo = async () => {
     const newTodos = todos.map((todo) =>
-      todo.id === edittingTodo.id ? edittingTodo : todo
+      todo.id === edittingTodo.id ? edittingTodo : todo,
     );
     setTodos(newTodos);
     setEdittingTodo({ id: -1, title: "" });

--- a/docs/4-advanced/04-react/_samples/todo-database/client/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-database/client/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/todo-database2/frontend/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-database2/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/todo-database2/frontend/src/App.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-database2/frontend/src/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
 
   const fixTodo = async () => {
     const newTodos = todos.map((todo) =>
-      todo.id === edittingTodo.id ? edittingTodo : todo
+      todo.id === edittingTodo.id ? edittingTodo : todo,
     );
     setTodos(newTodos);
     setEdittingTodo({ id: -1, title: "" });

--- a/docs/4-advanced/04-react/_samples/todo-database2/frontend/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-database2/frontend/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/todo-declarative/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-declarative/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/todo-dom/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-dom/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/4-advanced/04-react/_samples/todo-edit/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-edit/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/todo-edit/src/App.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-edit/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
 
   const fixTodo = () => {
     setTodos(
-      todos.map((todo) => (todo.id === edittingTodo.id ? edittingTodo : todo))
+      todos.map((todo) => (todo.id === edittingTodo.id ? edittingTodo : todo)),
     );
     setEdittingTodo({ id: -1, title: "" });
   };

--- a/docs/4-advanced/04-react/_samples/todo-edit/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-edit/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/_samples/todo-up-down/index.html
+++ b/docs/4-advanced/04-react/_samples/todo-up-down/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/4-advanced/04-react/_samples/todo-up-down/src/main.tsx
+++ b/docs/4-advanced/04-react/_samples/todo-up-down/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/4-advanced/04-react/index.md
+++ b/docs/4-advanced/04-react/index.md
@@ -135,7 +135,7 @@ React を使用するプロジェクトでは、通常 <Term type="jsx" strong>J
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 ```
 
@@ -759,7 +759,7 @@ const addTodo = () => {
 const removeTodo = (id: number) => {
   todos.splice(
     todos.findIndex((todo) => todo.id === id),
-    1
+    1,
   );
 };
 ```

--- a/docs/6-exercise/1-basis-of-web/_samples/blackjack/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/blackjack/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/1-basis-of-web/_samples/fibonacci/array/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/fibonacci/array/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/1-basis-of-web/_samples/fibonacci/recursion/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/fibonacci/recursion/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/1-basis-of-web/_samples/html/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/html/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/1-basis-of-web/_samples/length-of-name/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/length-of-name/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/1-basis-of-web/_samples/truck/index.html
+++ b/docs/6-exercise/1-basis-of-web/_samples/truck/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/1-basis-of-web/index.md
+++ b/docs/6-exercise/1-basis-of-web/index.md
@@ -21,7 +21,7 @@ HTML を用いて次のようなウェブサイトを作ってみましょう。
 <Answer>
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/10-typescript/_samples/welcome/main.ts
+++ b/docs/6-exercise/10-typescript/_samples/welcome/main.ts
@@ -13,7 +13,7 @@ function welcome(user: User) {
   } else {
     // この中では user は Premium 型として扱われる
     console.log(
-      `ようこそ ${user.name}さん プレミアム会員の有効期間は残り${user.daysLeft}日です`
+      `ようこそ ${user.name}さん プレミアム会員の有効期間は残り${user.daysLeft}日です`,
     );
   }
 }

--- a/docs/6-exercise/10-typescript/index.md
+++ b/docs/6-exercise/10-typescript/index.md
@@ -114,7 +114,7 @@ function welcome(user: User) {
   } else {
     // この中では user は Premium 型として扱われる
     console.log(
-      `ようこそ ${user.name}さん プレミアム会員の有効期間は残り${user.daysLeft}日です`
+      `ようこそ ${user.name}さん プレミアム会員の有効期間は残り${user.daysLeft}日です`,
     );
   }
 }

--- a/docs/6-exercise/11-react/_sample/index.html
+++ b/docs/6-exercise/11-react/_sample/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/11-react/_sample/src/App.tsx
+++ b/docs/6-exercise/11-react/_sample/src/App.tsx
@@ -67,7 +67,7 @@ function App() {
   // カテゴリを削除する関数
   const removeCategory = (existingCategory: string) => {
     setCategories(
-      categories.filter((category) => existingCategory != category)
+      categories.filter((category) => existingCategory != category),
     );
   };
 
@@ -140,7 +140,7 @@ function App() {
                     const todosLeft = todosCopy.filter(
                       (todo) =>
                         (todo.id != editingTodoId || todo.content != "") &&
-                        todo.category != category
+                        todo.category != category,
                     );
                     setTodos(todosLeft);
                     setEditingTodoId(-1);
@@ -151,7 +151,7 @@ function App() {
                   -
                 </button>
               </li>
-            )
+            ),
           )}
         </ul>
         <form
@@ -160,7 +160,7 @@ function App() {
             if (
               categoryInputInSideBar !== "" &&
               !categories.some(
-                (category) => category === categoryInputInSideBar
+                (category) => category === categoryInputInSideBar,
               )
             ) {
               addCategory(categoryInputInSideBar);
@@ -295,7 +295,7 @@ function App() {
                       />
                     </td>
                   </tr>
-                )
+                ),
               )
             )}
           </tbody>
@@ -313,7 +313,7 @@ function App() {
               categoryOfNewTodo = categoryInputInMainScreen;
               if (
                 !categories.some(
-                  (category) => category === categoryInputInMainScreen
+                  (category) => category === categoryInputInMainScreen,
                 )
               ) {
                 addCategory(categoryInputInMainScreen);

--- a/docs/6-exercise/11-react/_sample/src/main.tsx
+++ b/docs/6-exercise/11-react/_sample/src/main.tsx
@@ -5,5 +5,5 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/docs/6-exercise/2-easy-apps/_samples/bmi/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/bmi/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/2-easy-apps/_samples/calculator/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/calculator/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/2-easy-apps/_samples/drawing/answer/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/drawing/answer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/2-easy-apps/_samples/drawing/canvas-demo/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/drawing/canvas-demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/2-easy-apps/_samples/drawing/event-demo/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/drawing/event-demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/2-easy-apps/_samples/object-event/index.html
+++ b/docs/6-exercise/2-easy-apps/_samples/object-event/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/3-javascript/_samples/animals1/index.html
+++ b/docs/6-exercise/3-javascript/_samples/animals1/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/3-javascript/_samples/animals2/index.html
+++ b/docs/6-exercise/3-javascript/_samples/animals2/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/3-javascript/_samples/collatz-problem/index.html
+++ b/docs/6-exercise/3-javascript/_samples/collatz-problem/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/3-javascript/_samples/ranking/index.html
+++ b/docs/6-exercise/3-javascript/_samples/ranking/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/3-javascript/index.md
+++ b/docs/6-exercise/3-javascript/index.md
@@ -70,7 +70,7 @@ answer.textContent += 1;
 次のコードは、ブラウザ上に動物の鳴き声を表示するプログラムです。
 
 ```html title=index.html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
@@ -312,7 +312,7 @@ const sato = {
 まずは、HTML で表のひな形を作ります。
 
 ```html title=index.html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/4-css/_samples/1_fixed/index.html
+++ b/docs/6-exercise/4-css/_samples/1_fixed/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/4-css/_samples/2_relative-absolute/index.html
+++ b/docs/6-exercise/4-css/_samples/2_relative-absolute/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/4-css/_samples/3_sticky/index.html
+++ b/docs/6-exercise/4-css/_samples/3_sticky/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/4-css/_samples/block-inline1/index.html
+++ b/docs/6-exercise/4-css/_samples/block-inline1/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/4-css/_samples/block-inline2/index.html
+++ b/docs/6-exercise/4-css/_samples/block-inline2/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/4-css/_samples/flexbox-grid/index.html
+++ b/docs/6-exercise/4-css/_samples/flexbox-grid/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/4-css/_samples/responsive-design/index.html
+++ b/docs/6-exercise/4-css/_samples/responsive-design/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/4-css/index.md
+++ b/docs/6-exercise/4-css/index.md
@@ -37,7 +37,7 @@ import Details from "@theme/Details";
 - ブロックレベル要素の `height` やインライン要素の `width`, `height` の初期値は、中身の要素の大きさによって決まるので、`font-size` を変更することで大きさが変化します。また、開発者ツールで値を調べてみると、インライン要素の大きさは文字の大きさと同じになるのに対し、ブロックレベル要素の `height` は `font-size` の 1.5 倍になることがわかります。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -286,7 +286,7 @@ article div.title {
 <Details summary={<summary>HTML</summary>}>
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/5-browser-apps/_samples/flashcard/index.html
+++ b/docs/6-exercise/5-browser-apps/_samples/flashcard/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/5-browser-apps/_samples/timer/index.html
+++ b/docs/6-exercise/5-browser-apps/_samples/timer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/5-browser-apps/_samples/timer/script.js
+++ b/docs/6-exercise/5-browser-apps/_samples/timer/script.js
@@ -74,7 +74,7 @@ const timer = new Timer(
     startButton.disabled = true;
     stopButton.disabled = false;
     createAudioIfNone();
-  }
+  },
 );
 
 // 音が出ていなければ音を出す
@@ -121,7 +121,7 @@ setButton.onclick = () => {
   timer.setTimeLeft(
     Number(hourInput.value) * 1000 * 60 * 60 +
       Number(minuteInput.value) * 1000 * 60 +
-      Number(secondInput.value) * 1000
+      Number(secondInput.value) * 1000,
   );
 };
 

--- a/docs/6-exercise/6-express-and-ejs/_samples/express-no-ejs/main.js
+++ b/docs/6-exercise/6-express-and-ejs/_samples/express-no-ejs/main.js
@@ -5,7 +5,7 @@ const app = express();
 const departments = facultyData.engineering.departments;
 app.get("/", (request, response) => {
   response.send(
-    departments.map((department) => `<li>${department}</li>`).join("")
+    departments.map((department) => `<li>${department}</li>`).join(""),
   );
 });
 

--- a/docs/6-exercise/6-express-and-ejs/index.md
+++ b/docs/6-exercise/6-express-and-ejs/index.md
@@ -159,7 +159,7 @@ const app = express();
 const departments = facultyData.engineering.departments;
 app.get("/", (request, response) => {
   response.send(
-    departments.map((department) => `<li>${department}</li>`).join("")
+    departments.map((department) => `<li>${department}</li>`).join(""),
   );
 });
 
@@ -193,7 +193,7 @@ app.listen(3000);
 ```
 
 ```html title="template.ejs"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/6-exercise/7-get-and-post/_samples/login-form/static/index.html
+++ b/docs/6-exercise/7-get-and-post/_samples/login-form/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/7-get-and-post/index.md
+++ b/docs/6-exercise/7-get-and-post/index.md
@@ -48,7 +48,7 @@ app.listen(3000);
 ```
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/8-database-and-cookie/index.md
+++ b/docs/6-exercise/8-database-and-cookie/index.md
@@ -42,7 +42,7 @@ model Course {
 まず講師一覧表示用の画面を用意します
 
 ```html title=index.ejs
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
@@ -89,7 +89,7 @@ model Course {
 講義一覧のページを用意します。
 
 ```html title=courses.ejs
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/6-exercise/9-fetch-api/_samples/restaurants/static/index.html
+++ b/docs/6-exercise/9-fetch-api/_samples/restaurants/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/docs/9-old/day01/04.md
+++ b/docs/9-old/day01/04.md
@@ -5,7 +5,7 @@ title: HTMLの基礎
 先ほどの`index.html`をもう一度見直してみましょう。実は、HTML ファイルはただ文章を書けばよいというものではなく、いくつかの約束事があります。`index.html`を正しい HTML ファイルにするため、以下の通りに書き換えてください。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -32,7 +32,7 @@ HTML ファイルは、文書に意味を持たせるために、**タグ**と�
 また、全ての HTML ファイルは、一行目の
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 ```
 
 という「このファイルは HTML ファイルだ！」と宣言する定型句ののち、`html`要素を頂点とした木構造を形成します。

--- a/docs/9-old/day01/12.md
+++ b/docs/9-old/day01/12.md
@@ -16,7 +16,7 @@ title: CSSことはじめ
 これ以降、HTML を記述する際は、必要な部分のみを記述するものとします。例えば、上記の例であれば、実際の HTML ファイルは
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
@@ -48,7 +48,7 @@ Web サイトの見た目に対する社会の要求の高まりに応えて CSS
 CSS ファイルの拡張子は通常`.css`です。今回は`index.html`と併せて`style.css`を作成しました。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/9-old/day01/13.md
+++ b/docs/9-old/day01/13.md
@@ -5,7 +5,7 @@ title: "課題: CSSを用いてログインフォームをデザインする"
 VS Code で別のディレクトリを開き、Git リポジトリを初期化しましょう。`style.css`のみを使用して、次に示された HTML を装飾してください。
 
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/docs/9-old/day03/01.md
+++ b/docs/9-old/day03/01.md
@@ -12,7 +12,7 @@ const student1 = {
   age: 20,
 };
 document.write(
-  `Hello. I am ${student1.name}. I am ${student1["age"]} years old.`
+  `Hello. I am ${student1.name}. I am ${student1["age"]} years old.`,
 );
 ```
 

--- a/docs/9-old/day03/08.md
+++ b/docs/9-old/day03/08.md
@@ -54,7 +54,7 @@ DOM は非常に高度な枠組みです。今回の例でいえば、`HTMLDivEl
 ```js
 const sum = [1, 2, 3, 4, 5].reduce(
   (previous, current) => previous + current,
-  0
+  0,
 );
 console.log(sum); // 15
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "remark-math": "^3.0.1"
       },
       "devDependencies": {
-        "prettier": "2.8.4"
+        "prettier": "^3.0.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -10047,15 +10047,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -20808,9 +20808,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "node": ">=16.0.0"
   },
   "devDependencies": {
-    "prettier": "2.8.4"
+    "prettier": "^3.0.3"
   }
 }

--- a/src/components/Term/index.jsx
+++ b/src/components/Term/index.jsx
@@ -25,7 +25,7 @@ export default function Term({ type, strong = false, children }) {
     // 現在のページで用語が初出であればリンクを表示する必要がない
     const shouldLinkToReferencePage = Boolean(
       location.pathname !== term.referencePage &&
-        location.pathname + "/" !== term.referencePage
+        location.pathname + "/" !== term.referencePage,
     );
 
     return (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,7 +22,7 @@ function Home() {
             <Link
               className={clsx(
                 "button button--secondary button--lg",
-                styles.getStarted
+                styles.getStarted,
               )}
               to={useBaseUrl("docs/")}
             >


### PR DESCRIPTION
Prettier 3.0にバージョンアップしました。
- フォーマットの形式が変わりました。
   - https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki
   - https://prettier.io/blog/2023/07/05/3.0.0.html#print-html5-doctype-in-lowercase-7391httpsgithubcomprettierprettierpull7391-by-fiskerhttpsgithubcomfisker
- `.prettierignore`が`.gitignore`の内容をデフォルトで読むようになりました。