### PR TITLE
Format code of HTML section

### DIFF
--- a/docs/1-trial-session/02-html/index.md
+++ b/docs/1-trial-session/02-html/index.md
@@ -64,7 +64,7 @@ VS Code 上で作成したファイルは `index.html` でした。しかしな�
 
 <!-- prettier-ignore -->
 ```html title="index.html"
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
- 最新のPrettierの設定に合わせた。`prettier-ignore`があったせいで、ここだけ古いままになってしまっていた。なお、この`prettier-ignore`を消すと、`a`要素のフォーマットがかなりわかりにくくなるので消せない。