### PR TITLE
タイトルスクリーンの改善

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const katex = require("rehype-katex");
 /** @type {import("@docusaurus/types").Config} */
 module.exports = {
   title: "ut.code(); Learn",
-  tagline: "ut.code(); Learn",
+  tagline: "ut.code(); 公式教材",
   url: "https://learn.utcode.net/",
   baseUrl: "/",
   onBrokenLinks: "throw",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,10 +9,11 @@ import styles from "./styles.module.css";
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
+  console.log(context);
   return (
     <Layout
       title={`ut.code(); Learn`}
-      description="東京大学のソフトウェアエンジニアリングコミュニティ ut.code(); 内部向け学習資料です。"
+      description="東京大学のソフトウェアエンジニアリングコミュニティ ut.code(); の公式教材です。自由に利用可能です。"
     >
       <header className={clsx("hero hero--primary", styles.heroBanner)}>
         <div className="container">
@@ -32,8 +33,18 @@ function Home() {
         </div>
       </header>
       <main>
-        ut.code(); Learn は、東京大学のソフトウェアエンジニアリングコミュニティ
-        ut.code(); の内部向け学習資料です。
+        <p>
+          ut.code(); Learn
+          は、東京大学のソフトウェアエンジニアリングコミュニティである
+          ut.code(); の公式教材です。
+          <br />
+          この教材は、全くの未経験の状態からでも、自力で Web
+          サービスが開発できるようになれるようにするためのものであり、誰でも自由に利用可能です。
+        </p>
+        <footer>
+          ut.code();
+          は、非営利の大学のサークルであり、日本のWeb技術の発展をサポートしています。学習カリキュラムをオープンソースで公開しており、初心者からでも実際にサービスを開発できるようにしています。
+        </footer>
       </main>
     </Layout>
   );


### PR DESCRIPTION
・タイトルスクリーンの説明の改善
・ut.code(); Learnと二回繰り返されていて冗長だったので `ut.code(); 公式教材` に表示を変更