### PR TITLE
Remove indent in JSX

### DIFF
--- a/docs/1-trial-session/01-get-started/index.mdx
+++ b/docs/1-trial-session/01-get-started/index.mdx
@@ -17,14 +17,10 @@ Google Chrome は、[公式サイト](https://www.google.com/intl/ja_jp/chrome/)
 
 <Tabs groupId="os">
   <TabItem value="mac" label="macOS">
-
-<video src={installChromeOnMacVideo} controls />
-
+    <video src={installChromeOnMacVideo} controls />
   </TabItem>
   <TabItem value="win" label="Windows">
-
-<video src={installChromeOnWindowsVideo} controls />
-
+    <video src={installChromeOnWindowsVideo} controls />
   </TabItem>
 </Tabs>
 
@@ -36,14 +32,10 @@ Visual Studio Code は、[公式サイト](https://code.visualstudio.com)から�
 
 <Tabs groupId="os">
   <TabItem value="mac" label="macOS">
-
-<video src={installVscodeOnMacVideo} controls />
-
+    <video src={installVscodeOnMacVideo} controls />
   </TabItem>
   <TabItem value="win" label="Windows">
-
-<video src={installVscodeOnWindowsVideo} controls />
-
+    <video src={installVscodeOnWindowsVideo} controls />
   </TabItem>
 </Tabs>
 

--- a/docs/3-web-servers/02-node-js/index.mdx
+++ b/docs/3-web-servers/02-node-js/index.mdx
@@ -79,21 +79,19 @@ v18.16.0
 
 <Tabs groupId="os">
   <TabItem value="mac" label="macOS">
+    macOS の場合、インストールコマンドを実行してターミナルを再起動しても、`nvm` が使用できない場合があります。その場合、次のコマンドを実行してみてください。
 
-macOS の場合、インストールコマンドを実行してターミナルを再起動しても、`nvm` が使用できない場合があります。その場合、次のコマンドを実行してみてください。
+    ```shell
+    touch ~/.zshrc
+    ```
 
-```shell
-touch ~/.zshrc
-```
-
-<video src={installNvmInMacVideo} controls />
+    <video src={installNvmInMacVideo} controls />
 
   </TabItem>
   <TabItem value="win" label="Windows (WSL)">
+    Windows 上での作業は、WSL のターミナルを利用するようにしましょう。
 
-Windows 上での作業は、WSL のターミナルを利用するようにしましょう。
-
-<video src={installNvmInWslVideo} controls />
+    <video src={installNvmInWslVideo} controls />
 
   </TabItem>
 </Tabs>

--- a/docs/3-web-servers/09-git-github-init/index.mdx
+++ b/docs/3-web-servers/09-git-github-init/index.mdx
@@ -17,16 +17,13 @@ import addSshKeyVideo from "./add-ssh-key.mp4";
 
 <Tabs groupId="os">
   <TabItem value="mac" label="macOS">
+    macOS の場合は、コマンドラインデベロッパツールが必要です。
 
-macOS の場合は、コマンドラインデベロッパツールが必要です。
-
-<video src={installCommandLineDeveloperToolsVideo} controls muted />
+    <video src={installCommandLineDeveloperToolsVideo} controls muted />
 
   </TabItem>
   <TabItem value="win" label="Windows (WSL)">
-
-WSL を利用する場合は Git は標準搭載なので追加でインストールする必要はありません。
-
+    WSL を利用する場合は Git は標準搭載なので追加でインストールする必要はありません。
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
MDX v3になったことにより、JSX内でのMarkdownのインデントが不要になり、前後の空行も不要になったので削除 #531 