### PR TITLE
Remove import of React

### DIFF
--- a/src/components/Answer/index.jsx
+++ b/src/components/Answer/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Details from "@theme/Details";
 
 /**

--- a/src/components/ExternalVideoPlayer/index.jsx
+++ b/src/components/ExternalVideoPlayer/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./styles.module.css";
 
 /**

--- a/src/components/Term/index.jsx
+++ b/src/components/Term/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "@docusaurus/Link";
 import { useLocation } from "@docusaurus/router";
 import Tippy from "@tippyjs/react";

--- a/src/components/ViewSource/index.jsx
+++ b/src/components/ViewSource/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import clsx from "clsx";
 import { BiLinkExternal } from "react-icons/bi";
 import { SiGithub } from "react-icons/si";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import clsx from "clsx";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,4 +1,3 @@
-import React from "react";
 import MDXComponents from "@theme-original/MDXComponents";
 
 /* 


### PR DESCRIPTION
React 18から`React`のインポートが不要になったので、削除 #531 