### PR TITLE
inspector のショートカットキー調整

### DIFF
--- a/docs/2-browser-apps/01-inspector/index.mdx
+++ b/docs/2-browser-apps/01-inspector/index.mdx
@@ -15,7 +15,7 @@ Google Chrome 以外のブラウザにも開発者ツールは搭載されてい
 
 :::
 
-開発者ツールは、`F12` キー または `Ctrl + shift + I` キー (Windows)、
+開発者ツールは、`F12` キー または `Ctrl + Shift + I` キー (Windows)、
 もしくは `command + option + I` キー (Mac) を押すことにより起動できます。
 
 ![開発者ツールを起動した様子](open-inspector.png)

--- a/docs/2-browser-apps/01-inspector/index.mdx
+++ b/docs/2-browser-apps/01-inspector/index.mdx
@@ -15,7 +15,7 @@ Google Chrome 以外のブラウザにも開発者ツールは搭載されてい
 
 :::
 
-開発者ツールは、`F12` キー または `ctrl + shift + I` キー (Windows)、
+開発者ツールは、`F12` キー または `Ctrl + shift + I` キー (Windows)、
 もしくは `command + option + I` キー (Mac) を押すことにより起動できます。
 
 ![開発者ツールを起動した様子](open-inspector.png)

--- a/docs/2-browser-apps/01-inspector/index.mdx
+++ b/docs/2-browser-apps/01-inspector/index.mdx
@@ -15,7 +15,8 @@ Google Chrome 以外のブラウザにも開発者ツールは搭載されてい
 
 :::
 
-開発者ツールは、`command (Ctrl) + option (Shift) + I` キー、もしくは `F12` キーを押すことにより起動できます。
+開発者ツールは、`F12` キー または `ctrl + shift + I` キー (Windows)、
+もしくは `command + option + I` キー (Mac) を押すことにより起動できます。
 
 ![開発者ツールを起動した様子](open-inspector.png)
 


### PR DESCRIPTION
・ctrl などを小文字に
・ Mac だと F12 で開発者ツール開けなかった気がするので、 Windows に限定