### PR TITLE
Fix description of the inspector start command

### DIFF
--- a/docs/2-browser-apps/01-inspector/index.mdx
+++ b/docs/2-browser-apps/01-inspector/index.mdx
@@ -15,7 +15,7 @@ Google Chrome 以外のブラウザにも開発者ツールは搭載されてい
 
 :::
 
-開発者ツールは、`command (Ctrl) + option (Shift) + I` キー、もしくは `F12` キーを押すことにより起動できます。
+開発者ツールは、`command (Ctrl) + option (Shift) + I` キーを押すことにより起動できます。
 
 ![開発者ツールを起動した様子](open-inspector.png)
 


### PR DESCRIPTION
機種によって、`fn/Fn`キーを押すかの有無が異なるので、削除しました。このキーの名前も機種によって異なるため。