### PR TITLE
fs モジュールの関数から fs. を削除

### DIFF
--- a/docs/3-web-servers/03-module/index.mdx
+++ b/docs/3-web-servers/03-module/index.mdx
@@ -166,7 +166,7 @@ Hello World
 
 ### 課題
 
-[`fs.writeFileSync` 関数](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options)を用いて、ファイルに文字列を書き出してみましょう。
+`fs` モジュールの [`writeFileSync` 関数](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options)を用いて、ファイルに文字列を書き出してみましょう。
 
 <Answer>
 

--- a/docs/3-web-servers/03-module/index.mdx
+++ b/docs/3-web-servers/03-module/index.mdx
@@ -141,7 +141,7 @@ console.log(add(3, 4));
 
 ## 標準<Term>モジュール</Term>
 
-Node.js の [`fs` 標準モジュール](https://nodejs.org/api/fs.html) を用いると、Node.js からファイルの読み書きを行うことができます。[`fs.readFileSync` 関数](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options)は、ファイルの読み込みを行う関数で、第 1 引数にファイルを指定し、第 2 引数には文字コードを指定します。
+Node.js の [`fs` 標準モジュール](https://nodejs.org/api/fs.html) を用いると、Node.js からファイルの読み書きを行うことができます。`fs` モジュールの [`readFileSync` 関数](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options)は、ファイルの読み込みを行う関数で、第 1 引数にファイルを指定し、第 2 引数には文字コードを指定します。
 
 ```javascript title=main.mjs
 import { readFileSync } from "fs";

--- a/docs/3-web-servers/04-server/index.mdx
+++ b/docs/3-web-servers/04-server/index.mdx
@@ -232,7 +232,7 @@ const app = express();
 
 const names = ["田中", "鈴木", "佐藤"];
 app.get("/", (request, response) => {
-  const template = fs.readFileSync("./index.html", "utf-8");
+  const template = readFileSync("./index.html", "utf-8");
   const html = template.replace(
     "{users}",
     names.map((name) => `<li>${name}</li>`).join(""),
@@ -243,7 +243,7 @@ app.get("/", (request, response) => {
 app.listen(3000);
 ```
 
-リクエストを受け取ったとき、プログラムではまず `fs.readFileSync` 関数を用いて `index.html` ファイルの内容を文字列として読み込んでいます。
+リクエストを受け取ったとき、プログラムではまず `readFileSync` 関数を用いて `index.html` ファイルの内容を文字列として読み込んでいます。
 
 次の行で `String#replace` メソッドを用いて、読み込んだ HTML ファイルの中の `"{users}"` を、 `names` を箇条書きにした文字列に置換します。
 


### PR DESCRIPTION
`import { readFileSync } from "fs";`
のようにしてるので、多分動かない

それと `fs.writeFileSync` 関数を使って~ と書いてあるが、 サンプルコードでは `writeFileSync` 関数を使っていた (import {writeFileSync} のようにしているため)  ので  `readFileSync`  を使って～ に直した。