### PR TITLE
Fix description of named import

### DIFF
--- a/docs/3-web-servers/03-module/index.mdx
+++ b/docs/3-web-servers/03-module/index.mdx
@@ -91,7 +91,7 @@ console.log(add(3, 4));
 
 :::tip[名前付きエクスポート]
 
-上のように**デフォルトエクスポート**を使うと各モジュールで複数の関数をエクスポートすることができません。その場合は、**名前付きエクスポート**を用いることができます。[**分割代入**](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)の記法を用いることで、オブジェクトからプロパティを取り出して変数に代入する操作を簡潔に記述しています。
+上のように**デフォルトエクスポート**を使うと各モジュールで複数の関数をエクスポートすることができません。その場合は、**名前付きエクスポート**を用いることができます。
 
 ```javascript title="sub.mjs"
 export function add(a, b) {

--- a/docs/4-advanced/04-react/index.mdx
+++ b/docs/4-advanced/04-react/index.mdx
@@ -524,13 +524,13 @@ export default function App() {
 
 :::tip[配列の分割代入]
 
-オブジェクトと同じように、配列でも分割代入の記法を用いることができます。先ほどのプログラムにおいて
+先ほどのプログラムにおいて
 
 ```tsx
 const [count, setCount] = useState(0);
 ```
 
-は、次のように動作します。
+は、[**分割代入**](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)という記法であり、次のように動作します。
 
 ```tsx
 const useStateResult = useState(0);


### PR DESCRIPTION
named importの説明を修正し、それに合わせて分割代入の説明をReactのセクションに後ろ倒ししました。