### PR TITLE
太字のスタイルが壊れている箇所を修正

### DIFF
--- a/docs/1-trial-session/02-html/index.mdx
+++ b/docs/1-trial-session/02-html/index.mdx
@@ -92,7 +92,7 @@ VS Code 上で作成したファイルは `index.html` でした。しかしな�
 
 <video src={reloadBrowserVideo} muted controls />
 
-`<a href="https://www.google.com/">～</a>` は **`a` <Term>要素</Term>** です。<Term>開始タグ</Term>の中に `href="https://www.google.com/"` という部分があります。これが<Term>**属性**</Term>です。<Term>属性</Term>は、<Term>開始タグ</Term> の中に `属性名="値"` のように記述され、<Term>要素</Term>の特徴を表します。`a` <Term>要素</Term>の **`href` <Term>属性</Term>**は、ハイパーリンクのリンク先を表す<Term>属性</Term>です。
+`<a href="https://www.google.com/">～</a>` は **`a` <Term>要素</Term>** です。<Term>開始タグ</Term>の中に `href="https://www.google.com/"` という部分があります。これが<Term>**属性**</Term>です。<Term>属性</Term>は、<Term>開始タグ</Term> の中に `属性名="値"` のように記述され、<Term>要素</Term>の特徴を表します。`a` <Term>要素</Term>の **`href` <Term>属性</Term>** は、ハイパーリンクのリンク先を表す<Term>属性</Term>です。
 
 これにより、ハイパーリンクが設定されます。この例では `a` <Term>要素</Term>の中に `strong` <Term>要素</Term>が含まれています。このように、HTML タグは<Term type="htmlNest">**ネスト**</Term>させることにより、効果を重ね掛けすることができます。
 
@@ -112,7 +112,7 @@ VS Code 上で作成したファイルは `index.html` でした。しかしな�
 
 続けて記述されるのは `<html lang="ja">` 、つまり **`html` <Term>要素</Term>** です。<Term>HTML</Term> は、この `html` <Term>要素</Term>を根とした木構造になっています。このため、`html` <Term>タグ</Term>の閉じ<Term>タグ</Term>はファイルの末尾に現れます。
 
-`html` <Term>要素</Term>の直属の子<Term>要素</Term>は、**`head` <Term>要素</Term>**と**`body` <Term>要素</Term>**の二つだけです。このうち、後者 (`body` <Term>要素</Term>) が実際にブラウザの表示領域上に表示されることになります。
+`html` <Term>要素</Term>の直属の子<Term>要素</Term>は、 **`head` <Term>要素</Term>** と **`body` <Term>要素</Term>** の二つだけです。このうち、後者 (`body` <Term>要素</Term>) が実際にブラウザの表示領域上に表示されることになります。
 
 ![HTMLの構造](./html-structure.drawio.svg)
 

--- a/docs/1-trial-session/13-dom/index.mdx
+++ b/docs/1-trial-session/13-dom/index.mdx
@@ -40,7 +40,7 @@ element.textContent = "Hello DOM";
 
 ## <Term>HTML 要素</Term>のスタイルを変更する
 
-`document.getElementById` <Term>関数</Term>が返す<Term>オブジェクト</Term>の `style` <Term>プロパティ</Term>は、その要素の <Term>`style` 属性</Term>と対応します。**`style` <Term>プロパティ</Term>に格納されている<Term>値</Term>自体も<Term>オブジェクト</Term>**となっており、その各<Term>プロパティ</Term>が CSS の<Term type="cssProperty">プロパティ</Term>に対応します。
+`document.getElementById` <Term>関数</Term>が返す<Term>オブジェクト</Term>の `style` <Term>プロパティ</Term>は、その要素の <Term>`style` 属性</Term>と対応します。 **`style` <Term>プロパティ</Term>に格納されている<Term>値</Term>自体も<Term>オブジェクト</Term>** となっており、その各<Term>プロパティ</Term>が CSS の<Term type="cssProperty">プロパティ</Term>に対応します。
 
 ```js title="script.js"
 element.style.backgroundColor = "red";


### PR DESCRIPTION
`**` で囲んだ部分にインラインコードやタグが含まれており、かつ前後にスペースがない場合に太字にならないようだったので、いったん手動で前後にスペースを入れて修正しました。