### PR TITLE
最初に出てくる変数の名前を `myGreatName` から `myName` に変更

### DIFF
--- a/docs/1-trial-session/05-variables/index.mdx
+++ b/docs/1-trial-session/05-variables/index.mdx
@@ -14,13 +14,13 @@ title: 変数
 <Term>変数</Term>を使用するには、まず<Term>変数</Term>を<Term>**宣言**</Term>する必要があります。
 
 ```javascript title="script.js"
-let myName = "Becky Jones";
+let myName = "John Doe";
 document.write(myName);
 ```
 
-`let` は、<Term>変数</Term>を<Term>宣言</Term>するためのキーワードです。1 行目では、`myName` という名前の<Term>変数</Term>を<Term>宣言</Term>し、そこに文字列 `"Becky Jones"` を<Term>**代入**</Term>しています。`=` は<Term>代入</Term>を表し、左側に指定した<Term>変数</Term>に対し、右側に指定された<Term>値</Term>を<Term>代入</Term>します。
+`let` は、<Term>変数</Term>を<Term>宣言</Term>するためのキーワードです。1 行目では、`myName` という名前の<Term>変数</Term>を<Term>宣言</Term>し、そこに文字列 `"John Doe"` を<Term>**代入**</Term>しています。`=` は<Term>代入</Term>を表し、左側に指定した<Term>変数</Term>に対し、右側に指定された<Term>値</Term>を<Term>代入</Term>します。
 
-2 行目では、<Term>変数</Term> `myName` が<Term>評価</Term>され、<Term>代入</Term>されていた<Term>文字列</Term><Term>値</Term> `"Becky Jones"` が画面に表示されます。
+2 行目では、<Term>変数</Term> `myName` が<Term>評価</Term>され、<Term>代入</Term>されていた<Term>文字列</Term><Term>値</Term> `"John Doe"` が画面に表示されます。
 
 {/* prettier-ignore */}
 <Term>変数</Term>を<Term>宣言</Term>するキーワードには、`let` 以外にも `const` があります。
@@ -28,7 +28,7 @@ document.write(myName);
 違いについては、次の節で説明します。
 
 ```javascript title="script.js"
-const myName = "Becky Jones";
+const myName = "John Doe";
 document.write(myName);
 ```
 

--- a/docs/1-trial-session/05-variables/index.mdx
+++ b/docs/1-trial-session/05-variables/index.mdx
@@ -14,13 +14,13 @@ title: 変数
 <Term>変数</Term>を使用するには、まず<Term>変数</Term>を<Term>**宣言**</Term>する必要があります。
 
 ```javascript title="script.js"
-let myGreatName = "Becky Jones";
-document.write(myGreatName);
+let myName = "Becky Jones";
+document.write(myName);
 ```
 
-`let` は、<Term>変数</Term>を<Term>宣言</Term>するためのキーワードです。1 行目では、`myGreatName` という名前の<Term>変数</Term>を<Term>宣言</Term>し、そこに文字列 `"Becky Jones"` を<Term>**代入**</Term>しています。`=` は<Term>代入</Term>を表し、左側に指定した<Term>変数</Term>に対し、右側に指定された<Term>値</Term>を<Term>代入</Term>します。
+`let` は、<Term>変数</Term>を<Term>宣言</Term>するためのキーワードです。1 行目では、`myName` という名前の<Term>変数</Term>を<Term>宣言</Term>し、そこに文字列 `"Becky Jones"` を<Term>**代入**</Term>しています。`=` は<Term>代入</Term>を表し、左側に指定した<Term>変数</Term>に対し、右側に指定された<Term>値</Term>を<Term>代入</Term>します。
 
-2 行目では、<Term>変数</Term> `myGreatName` が<Term>評価</Term>され、<Term>代入</Term>されていた<Term>文字列</Term><Term>値</Term> `"Becky Jones"` が画面に表示されます。
+2 行目では、<Term>変数</Term> `myName` が<Term>評価</Term>され、<Term>代入</Term>されていた<Term>文字列</Term><Term>値</Term> `"Becky Jones"` が画面に表示されます。
 
 {/* prettier-ignore */}
 <Term>変数</Term>を<Term>宣言</Term>するキーワードには、`let` 以外にも `const` があります。
@@ -28,11 +28,11 @@ document.write(myGreatName);
 違いについては、次の節で説明します。
 
 ```javascript title="script.js"
-const myGreatName = "Becky Jones";
-document.write(myGreatName);
+const myName = "Becky Jones";
+document.write(myName);
 ```
 
-ここまでの例では、`my great name` というフレーズを、`myGreatName` のように記述しています。
+ここまでの例では、`my name` というフレーズを、`myName` のように記述しています。
 
 このように、複数の単語にわたるフレーズを、2 語目以降の先頭の文字を大文字にして結合する命名規則を、<Term>**キャメルケース**</Term>と呼びます。
 


### PR DESCRIPTION
最初に出てくる変数の名前を `myGreatName` から `myName` に変更しました。
読者が "great" が入っている意図が分からず混乱することを防ぐためです。