### PR TITLE
標準モジュールの表記を統一

### DIFF
--- a/docs/3-web-servers/04-module/index.mdx
+++ b/docs/3-web-servers/04-module/index.mdx
@@ -88,7 +88,7 @@ console.log(add(3, 4));
 
 ## 標準<Term>モジュール</Term>
 
-Node.js の [`fs` 標準モジュール](https://nodejs.org/api/fs.html) を用いると、Node.js からファイルの読み書きを行うことができます。`fs` モジュールの [`readFileSync` 関数](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options)は、ファイルの読み込みを行う関数で、第 1 引数にファイルへのパスを指定し、第 2 引数には文字コードを指定します。
+Node.js の [`fs` モジュール](https://nodejs.org/api/fs.html) を用いると、Node.js からファイルの読み書きを行うことができます。`fs` モジュールの [`readFileSync` 関数](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options)は、ファイルの読み込みを行う関数で、第 1 引数にファイルへのパスを指定し、第 2 引数には文字コードを指定します。
 
 ```javascript title="main.mjs"
 import { readFileSync } from "node:fs";

--- a/docs/3-web-servers/05-server/index.mdx
+++ b/docs/3-web-servers/05-server/index.mdx
@@ -71,10 +71,10 @@ node main.mjs
 
 そして [`express.Response#send` メソッド](https://expressjs.com/ja/api.html#res.send)により、クライアントが必要なデータを送信することができます。
 
-:::tip[`http`標準<Term>モジュール</Term>]
-`express` を使わずに Node.js 単体で Web サーバーを作成するには、`http` 標準<Term>モジュール</Term>を使用します。
+:::tip[`http` <Term>モジュール</Term>]
+`express` を使わずに Node.js 単体で Web サーバーを作成するには、`http` <Term>モジュール</Term>を使用します。
 
-`http` 標準モジュールを使って 簡単な Web サーバーを構築すると以下のようなコードになります。
+`http` モジュールを使って 簡単な Web サーバーを構築すると以下のようなコードになります。
 
 ```javascript title="main.mjs"
 import { Server } from "http";


### PR DESCRIPTION
`fs` モジュールと`fs` 標準モジュールの表記が混ざっていたので、統一しました。
`http` 標準モジュールの表記もそれに合わせて修正しました。