### PR TITLE
Carクラスを定義する問題での単位の表記を修正

### DIFF
--- a/docs/2-browser-apps/03-class/_samples/car-class/script.js
+++ b/docs/2-browser-apps/03-class/_samples/car-class/script.js
@@ -6,4 +6,6 @@ class Car {
 const prius = new Car();
 prius.cost = 2600000;
 
-document.write(`重さは${prius.weightInTons}tで、値段は${prius.cost}円です。`);
+document.write(
+  `重さは${prius.weightInTons}トンで、値段は${prius.cost}円です。`,
+);

--- a/docs/2-browser-apps/03-class/index.mdx
+++ b/docs/2-browser-apps/03-class/index.mdx
@@ -75,7 +75,9 @@ class Car {
 const prius = new Car();
 prius.cost = 2600000;
 
-document.write(`重さは${prius.weightInTons}tで、値段は${prius.cost}円です。`);
+document.write(
+  `重さは${prius.weightInTons}トンで、値段は${prius.cost}円です。`,
+);
 ```
 
 <ViewSource url={import.meta.url} path="_samples/car-class" />


### PR DESCRIPTION
単位と数字の間には、半角スペースを入れないといけないという決まりがあります。(英語は分かち書きをすることから、日本語でもそうするという決まりになっています。)
一方で、一般的に日本語では分かち書きをしないため、日本語表記の単位は一般的な文脈では半角スペースを入れないこともあります。
ということで、表記を日本語にすることにより半角スペースを入れなくても間違いとは言えなくなるようにしました。