### PR TITLE
GitHub Actionsの設定をアップデート

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install Packages
@@ -36,9 +36,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install Packages


### PR DESCRIPTION
`actions/setup-node`のバージョンを最新にして、Node.jsのバージョンも`.nvmrc`から読むようにしました。