### PR TITLE
「フォーム」の章の`node-emoji`に関する演習問題に`ViewSource`コンポーネントを追加

### DIFF
--- a/docs/3-web-servers/06-form/index.mdx
+++ b/docs/3-web-servers/06-form/index.mdx
@@ -163,6 +163,8 @@ app.get("/emojify", (request, response) => {
 app.listen(3000);
 ```
 
+<ViewSource url={import.meta.url} path="_samples/node-emoji-form" />
+
 </Answer>
 
 ## 中級演習


### PR DESCRIPTION
`ViewSource`コンポーネントはすべての解答に置くことが想定されますが、この演習問題には置かれていなかったため設置しました。