### PR TITLE
GitHub ActionsでGoogle Analytics Tracking IDを環境変数として設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           fetch-depth: 0
       - run: npm ci && npm run build
+        env:
+          GOOGLE_ANALYTICS_TRACKING_ID: ${{ vars.GOOGLE_ANALYTICS_TRACKING_ID }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,6 +42,9 @@ const config = {
             "./src/css/custom.css",
           ],
         },
+        gtag: process.env.GOOGLE_ANALYTICS_TRACKING_ID && {
+          trackingID: process.env.GOOGLE_ANALYTICS_TRACKING_ID,
+        },
       },
     ],
   ],


### PR DESCRIPTION
## 概要
Repository variablesに設定された`GOOGLE_ANALYTICS_TRACKING_ID`をGitHub Actionsのビルド時に環境変数として渡すように修正しました。

## 変更内容
- `.github/workflows/deploy.yml`のbuildステップに`env`セクションを追加
- `${{ vars.GOOGLE_ANALYTICS_TRACKING_ID }}`を使用してRepository variablesから値を取得

## 背景
Repository variablesは自動的に環境変数として渡されないため、明示的に指定する必要があります。