### PR TITLE
`.gitignore`での`/generated/prisma`の書き方をアップデート

### DIFF
--- a/docs/3-web-servers/08-database/_samples/forum/.gitignore
+++ b/docs/3-web-servers/08-database/_samples/forum/.gitignore
@@ -1,3 +1,3 @@
 /node_modules
 /.env
-/generated
+/generated/prisma


### PR DESCRIPTION
現在では`npx prisma init`で作成される`.gitignore`に`npx prisma generate`で生成されたファイルが記載されるようになりました。ここで、`/generated/prisma`という表記になっていたため、これに合わせるようにしました。
cf. https://www.prisma.io/docs/orm/reference/prisma-cli-reference#generated-assets